### PR TITLE
update all deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Hello World (C++ to WASM/JS) using Bazel with Emscritpen
 
-This repository demonstrates compiling C++ code with Bazel to either WebAssembly or plain JavaScript using the lastest Emscripten release.
+This repository demonstrates compiling C++ code with Bazel to either WebAssembly or plain JavaScript.
+
+Works with the following versions (as of 3/21/20201):
+- bazel 4.0.0
+- emscripten 2.0.15
 
 ### [Link to blog post](https://medium.com/@s0l0ist/c-to-webassembly-using-bazel-and-emscripten-ae797c119bef)
 

--- a/hello-world/javascript/BUILD
+++ b/hello-world/javascript/BUILD
@@ -1,18 +1,20 @@
 package(default_visibility = ["//visibility:public"])
 
 DEFAULT_EMSCRIPTEN_LINKOPTS = [
-    "-flto",                        # Specify lto (has to be set on for compiler as well)
-    "--bind",                       # Compiles the source code using the Embind bindings to connect C/C++ and JavaScript
-    "--closure 1",                  # Run the closure compiler
-    "-s MALLOC=emmalloc",           # Switch to using the much smaller implementation
-    "-s ALLOW_MEMORY_GROWTH=0",     # Our example doesn't need memory growth
-    "-s USE_PTHREADS=0",            # Disable pthreads
-    "-s ASSERTIONS=0",              # Turn off assertions
-    "-s EXPORT_ES6=1",              # Export as es6 module, used for rollup
-    "-s MODULARIZE=1",              # Allows us to manually invoke the initializatio of wasm
-    "-s EXPORT_NAME=createModule",  # Not used, but good to specify
-    "-s USE_ES6_IMPORT_META=0",     # Disable loading from import meta since we use rollup
-    "-s SINGLE_FILE=1"              # Pack all webassembly into base64
+    "-flto",                            # Specify lto (has to be set on for compiler as well)
+    "--bind",                           # Compiles the source code using the Embind bindings to connect C/C++ and JavaScript
+    "--closure 1",                      # Run the closure compiler
+    "-s MALLOC=emmalloc",               # Switch to using the much smaller implementation
+    "-s ALLOW_MEMORY_GROWTH=0",         # Our example doesn't need memory growth
+    "-s USE_PTHREADS=0",                # Disable pthreads
+    "-s ASSERTIONS=0",                  # Turn off assertions
+    "-s EXPORT_ES6=1",                  # Export as es6 module, used for rollup
+    "-s MODULARIZE=1",                  # Allows us to manually invoke the initializatio of wasm
+    "-s EXPORT_NAME=createModule",      # Not used, but good to specify
+    "-s USE_ES6_IMPORT_META=0",         # Disable loading from import meta since we use rollup
+    "-s SINGLE_FILE=1",                 # Pack all webassembly into base64
+    "-s DISABLE_EXCEPTION_CATCHING=1",  # Disable all exception catching
+    "-s NODEJS_CATCH_EXIT=0",           # We don't have a 'main' so disable exit() catching
 ]
 ASMJS_LINKOPTS = [
     "-s WASM=0",                    # Specify asm.js output

--- a/hello-world/javascript/scripts/em-update.sh
+++ b/hello-world/javascript/scripts/em-update.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 
 # Updates emsdk to the latest version
 cd ./submodules/emsdk/ \
-&& ./emsdk update-tags \
+&& git pull \
 && cd ../../

--- a/hello-world/javascript/toolchain/cc_toolchain_config.bzl
+++ b/hello-world/javascript/toolchain/cc_toolchain_config.bzl
@@ -80,20 +80,25 @@ def _impl(ctx):
                 flag_groups = [
                     flag_group(
                         flags = [
+                            # The clang compiler comes with a definition of
+                            # max_align_t struct in $emsdk/upstream/lib/clang/13.0.0/include/__stddef_max_align_t.h.
+                            # It conflicts with the one defined in
+                            # $emsdk/upstream/emscripten/cache/sysroot/include/bits/alltypes.h.
+                            # We need both include paths to make things work.
+                            #
+                            # To workaround this, we are defining the following
+                            # symbol through compiler flag so that the max_align_t
+                            # defined in clang's header file will be skipped.
+                            "-D",
+                            "__CLANG_MAX_ALIGN_T_DEFINED",
+                            # We are using emscripten 2.0.15 for this build. It
+                            # comes with clang 13.0.0. Future emscripten release
+                            # might change the clang version number below.
+                            #
+                            # Also need to change the version number in
+                            # cxx_cxx_builtin_include_directories below.
                             "-isystem",
-                            "external/emsdk/emsdk/upstream/emscripten/system/include/libcxx",
-                            "-isystem",
-                            "external/emsdk/emsdk/upstream/emscripten/system/lib/libcxxabi/include",
-                            "-isystem",
-                            "external/emsdk/emsdk/upstream/emscripten/system/include/compat",
-                            "-isystem",
-                            "external/emsdk/emsdk/upstream/emscripten/system/include",
-                            "-isystem",
-                            "external/emsdk/emsdk/upstream/emscripten/system/include/libc",
-                            "-isystem",
-                            "external/emsdk/emsdk/upstream/emscripten/system/lib/libc/musl/arch/emscripten",
-                            "-isystem",
-                            "external/emsdk/emsdk/upstream/emscripten/system/local/include",
+                            "external/emsdk/emsdk/upstream/lib/clang/13.0.0/include",
                         ],
                     ),
                 ],
@@ -111,7 +116,7 @@ def _impl(ctx):
         # In advanced C++ apps, -O3 can break asmjs.
         flag_set(
             actions = all_compile_actions + all_link_actions,
-            flag_groups = [flag_group(flags = ["-g0", "-O3"])], 
+            flag_groups = [flag_group(flags = ["-g0", "-O3"])],
             with_features = [with_feature_set(features = ["opt"])],
         ),
         # Fastbuild (fastbuild)
@@ -151,18 +156,35 @@ def _impl(ctx):
         ),
     ]
 
+    cxx_builtin_include_directories = [
+        "external/emsdk/emsdk/upstream/emscripten/cache/sysroot/include/c++/v1",
+        "external/emsdk/emsdk/upstream/emscripten/cache/sysroot/include/compat",
+        "external/emsdk/emsdk/upstream/emscripten/cache/sysroot/include",
+        # We are using emscripten 2.0.15 for this build. It comes with clang
+        # 13.0.0. Future emscripten release might change the clang version
+        # number below.
+        #
+        # Also need to change the version number in
+        # toolchain_include_directories_feature above.
+        "external/emsdk/emsdk/upstream/lib/clang/13.0.0/include",
+    ]
+
+    builtin_sysroot = "external/emsdk/emsdk/upstream/emscripten/cache/sysroot"
+
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         toolchain_identifier = "wasm-toolchain",
         host_system_name = "i686-unknown-linux-gnu",
         target_system_name = "wasm-unknown-emscripten",
         target_cpu = "wasm",
-        target_libc = "unknown",
+        target_libc = "musl/js",
         compiler = "emscripten",
-        abi_version = "unknown",
-        abi_libc_version = "unknown",
+        abi_version = "emscripten_syscalls",
+        abi_libc_version = "default",
         tool_paths = tool_paths,
         features = features,
+        builtin_sysroot = builtin_sysroot,
+        cxx_builtin_include_directories = cxx_builtin_include_directories,
     )
 
 cc_toolchain_config = rule(

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.12.13"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -90,9 +90,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
     },
@@ -135,25 +135,34 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
-    "rollup": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.10.7.tgz",
-      "integrity": "sha512-rofUSH2i4GymWhQq6bfRaSiVbz4LEB4h/7+AhuXCaeOSwQqClD0hINjs59j8SyfQwcqe83NcVJAY2kjp0h33bQ==",
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.1.2"
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "rollup": {
+      "version": "2.42.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.42.1.tgz",
+      "integrity": "sha512-/y7M2ULg06JOXmMpPzhTeQroJSchy8lX8q6qrjqil0jmLz6ejCWbQzVnWTsdmMQRhfU0QcwtiW8iZlmrGXWV4g==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.1"
       }
     },
     "rollup-plugin-terser": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-      "integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz",
+      "integrity": "sha512-1pkwkervMJQGFYvM9nscrUoncPwiKR/K+bHdjv6PFgRo3cgPHoRT83y2Aa3GvINj4539S15t/tpFPb775TDs6w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
         "jest-worker": "^24.9.0",
         "rollup-pluginutils": "^2.8.2",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "terser": "^4.6.2"
       }
     },
@@ -166,11 +175,20 @@
         "estree-walker": "^0.6.1"
       }
     },
-    "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -198,9 +216,9 @@
       }
     },
     "terser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.7.0.tgz",
-      "integrity": "sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "em:init": "bash hello-world/javascript/scripts/em-init.sh"
   },
   "devDependencies": {
-    "rollup": "^2.10.7",
-    "rollup-plugin-terser": "^5.3.0"
+    "rollup": "^2.42.1",
+    "rollup-plugin-terser": "^5.3.1"
   }
 }


### PR DESCRIPTION
This PR updates all the project dependencies:
- Assumes the latest Bazel 4.0.0 is installed
- Updates emsdk to use emscripten 2.0.15
- Upgrades all devDependencies in package.json

Inspiration taken from TensorFlowJS.